### PR TITLE
Update packages to latest versions

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - OneSignal (2.10.1)
+  - OneSignal (2.12.3)
   - React (0.60.5):
     - React-Core (= 0.60.5)
     - React-DevSupport (= 0.60.5)
@@ -57,12 +57,12 @@ PODS:
     - React-cxxreact (= 0.60.5)
     - React-jsi (= 0.60.5)
   - React-jsinspector (0.60.5)
-  - react-native-key-pair (1.1.0):
+  - react-native-key-pair (1.1.1):
     - React
-  - react-native-onesignal (3.3.2):
-    - OneSignal (= 2.10.1)
+  - react-native-onesignal (3.6.1):
+    - OneSignal (= 2.12.3)
     - React (< 1.0.0, >= 0.13.0)
-  - react-native-webview (7.0.4):
+  - react-native-webview (7.6.0):
     - React
   - React-RCTActionSheet (0.60.5):
     - React-Core (= 0.60.5)
@@ -89,7 +89,7 @@ PODS:
     - React-Core (= 0.60.5)
   - RNCAsyncStorage (1.6.1):
     - React
-  - RNDeviceInfo (2.3.2):
+  - RNDeviceInfo (3.1.4):
     - React
   - yoga (0.60.5.React)
 
@@ -122,7 +122,7 @@ DEPENDENCIES:
   - yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - boost-for-react-native
     - OneSignal
 
@@ -185,7 +185,7 @@ SPEC CHECKSUMS:
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  OneSignal: 8fb749fa07f88006403c9b659a570fb7fb74519a
+  OneSignal: 30b6e03a1f14169c4313e301a7b7bdf467b5a575
   React: 53c53c4d99097af47cf60594b8706b4e3321e722
   React-Core: ba421f6b4f4cbe2fb17c0b6fc675f87622e78a64
   React-cxxreact: 8384287780c4999351ad9b6e7a149d9ed10a2395
@@ -193,9 +193,9 @@ SPEC CHECKSUMS:
   React-jsi: 4d8c9efb6312a9725b18d6fc818ffc103f60fec2
   React-jsiexecutor: 90ad2f9db09513fc763bc757fdc3c4ff8bde2a30
   React-jsinspector: e08662d1bf5b129a3d556eb9ea343a3f40353ae4
-  react-native-key-pair: 4d076872a695a686cea4e1afd0053da2811f7df9
-  react-native-onesignal: 93d50629a3f38df9df81178280ce7e7da6c29f05
-  react-native-webview: d4bce5544a9976e29001384169211242398e9b8c
+  react-native-key-pair: 72c741a233128638efec38ef62f77a136296254e
+  react-native-onesignal: d029b061807f5d14eaf765293099987f942d19f8
+  react-native-webview: 711cef318a554093b09a5b871894011435d87a8d
   React-RCTActionSheet: b0f1ea83f4bf75fb966eae9bfc47b78c8d3efd90
   React-RCTAnimation: 359ba1b5690b1e87cc173558a78e82d35919333e
   React-RCTBlob: 5e2b55f76e9a1c7ae52b826923502ddc3238df24
@@ -207,9 +207,9 @@ SPEC CHECKSUMS:
   React-RCTVibration: 2105b2e0e2b66a6408fc69a46c8a7fb5b2fdade0
   React-RCTWebSocket: cd932a16b7214898b6b7f788c8bddb3637246ac4
   RNCAsyncStorage: 621bad7a889b5bf1583a52547f2dcd3a4d1ff15e
-  RNDeviceInfo: bdc3e922b2ed0f086e9d9ab534e61bc316f08576
+  RNDeviceInfo: 9e88577c51bd42f65275e53bb0de0a0f728ed6b8
   yoga: 312528f5bbbba37b4dcea5ef00e8b4033fdd9411
 
 PODFILE CHECKSUM: 6301c06537eb2e3354a878375f9cf0e20e2dd4ec
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -291,15 +291,116 @@
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.1.0.tgz",
-			"integrity": "sha512-3fOK0L+Fdlg8S5al8u/hWE6vhufGSn0bN09xm2LXMy//REAF8kDCrYoOBKYmA8m5Nom+sV9LyLCwrFynA8/slg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.7.4.tgz",
+			"integrity": "sha512-Sk4xmtVdM9sA/jCI80f+KS+Md+ZHIpjuqmYPk1M7F/upHou5e4ReYmExAiu6PVe65BhJPZA2CY9x9k4BqE5klw==",
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-wrap-function": "^7.1.0",
-				"@babel/template": "^7.1.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-annotate-as-pure": "^7.7.4",
+				"@babel/helper-wrap-function": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			},
+			"dependencies": {
+				"@babel/generator": {
+					"version": "7.7.7",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+					"integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-annotate-as-pure": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.7.4.tgz",
+					"integrity": "sha512-2BQmQgECKzYKFPpiycoF9tlb5HA4lrVyAmLLVK177EcQAqjVLciUb2/R+n1boQ9y5ENV3uz2ZqiNw7QMBBw1Og==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+					"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+					"integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw=="
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+					"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+					"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
 			}
 		},
 		"@babel/helper-replace-supers": {
@@ -331,14 +432,107 @@
 			}
 		},
 		"@babel/helper-wrap-function": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz",
-			"integrity": "sha512-o9fP1BZLLSrYlxYEYyl2aS+Flun5gtjTIG8iln+XuEzQTs0PLagAGSXUcqruJwD5fM48jzIEggCKpIfWTcR7pQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.7.4.tgz",
+			"integrity": "sha512-VsfzZt6wmsocOaVU0OokwrIytHND55yvyT4BPB9AIIgwr8+x7617hetdJTsuGwygN5RC6mxA9EJztTjuwm2ofg==",
 			"requires": {
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/template": "^7.1.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.2.0"
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			},
+			"dependencies": {
+				"@babel/generator": {
+					"version": "7.7.7",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+					"integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+					"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+					"integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw=="
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+					"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+					"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
 			}
 		},
 		"@babel/helpers": {
@@ -467,9 +661,9 @@
 			"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g=="
 		},
 		"@babel/plugin-external-helpers": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.2.0.tgz",
-			"integrity": "sha512-QFmtcCShFkyAsNtdCM3lJPmRe1iB+vPZymlB4LnDIKEBj2yKQLQKtoxXxJ8ePT5fwMl4QGg303p4mB0UsSI2/g==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-external-helpers/-/plugin-external-helpers-7.7.4.tgz",
+			"integrity": "sha512-RVGNajLaFlknbZLutaP/uv7Q+xmVs2LMlEWFXbcjLnwtBdPqAVpV3nzYIAJqri/VjJCUrhG5nALijtg0aND+XA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -529,9 +723,9 @@
 			}
 		},
 		"@babel/plugin-syntax-class-properties": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.2.0.tgz",
-			"integrity": "sha512-UxYaGXYQ7rrKJS/PxIKRkv3exi05oH7rokBAsmCSsCxz1sVPZ7Fu6FzKoGgUvmY+0YgSkYHgUoCh5R5bCNBQlw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.7.4.tgz",
+			"integrity": "sha512-JH3v5ZOeKT0qqdJ9BeBcZTFQiJOMax8RopSr1bH6ASkZKo2qWsvBML7W1mp89sszBRDBBRO8snqcByGdrMTdMg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -617,19 +811,39 @@
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.5.0.tgz",
-			"integrity": "sha512-mqvkzwIGkq0bEF1zLRRiTdjfomZJDV33AH3oQzHVGkI2VzEmXLpKKOBvEVaFZBJdN0XTyH38s9j/Kiqr68dggg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.7.4.tgz",
+			"integrity": "sha512-zpUTZphp5nHokuy8yLlyafxCJ0rSlFoSHypTUWgpdwoDXWQcseaect7cJ8Ppk6nunOM6+5rPMkod4OYKPR5MUg==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-module-imports": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-remap-async-to-generator": "^7.1.0"
+				"@babel/helper-remap-async-to-generator": "^7.7.4"
+			},
+			"dependencies": {
+				"@babel/helper-module-imports": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.4.tgz",
+					"integrity": "sha512-dGcrX6K9l8258WFjyDLJwuVKxR4XZfU0/vTUgOQYWEnRD8mgr+p4d6fCUMq/ys0h4CCt/S5JhbvtyErjWouAUQ==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				}
 			}
 		},
 		"@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.2.0.tgz",
-			"integrity": "sha512-ntQPR6q1/NKuphly49+QiQiTN0O63uOwjdD6dhIjSWBI5xlrbUFh720TIpzBhpnrLfv2tNH/BXvLIab1+BAI0w==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.7.4.tgz",
+			"integrity": "sha512-kqtQzwtKcpPclHYjLK//3lH8OFsCDuDJBaFhVwf8kqdnF6MN4l618UDlcA7TfRs3FayrHj+svYnSX8MC9zmUyQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -718,9 +932,9 @@
 			}
 		},
 		"@babel/plugin-transform-member-expression-literals": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.2.0.tgz",
-			"integrity": "sha512-HiU3zKkSU6scTidmnFJ0bMX8hz5ixC93b4MHMiYebmk2lUVNGOboPsqQvx5LzooihijUoLR/v7Nc1rbBtnc7FA==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.7.4.tgz",
+			"integrity": "sha512-9VMwMO7i69LHTesL0RdGy93JU6a+qOPuvB4F4d0kR0zyVjJRVJRaoaGjhtki6SzQUu8yen/vxPKN6CWnCUw6bA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -745,12 +959,132 @@
 			}
 		},
 		"@babel/plugin-transform-object-super": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.5.5.tgz",
-			"integrity": "sha512-un1zJQAhSosGFBduPgN/YFNvWVpRuHKU7IHBglLoLZsGmruJPOo6pbInneflUdmq7YvSVqhpPs5zdBvLnteltQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.7.4.tgz",
+			"integrity": "sha512-ho+dAEhC2aRnff2JCA0SAK7V2R62zJd/7dmtoe7MHcso4C2mS+vZjn1Pb1pCVZvJs1mgsvv5+7sT+m3Bysb6eg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.5.5"
+				"@babel/helper-replace-supers": "^7.7.4"
+			},
+			"dependencies": {
+				"@babel/generator": {
+					"version": "7.7.7",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+					"integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.7.4.tgz",
+					"integrity": "sha512-9KcA1X2E3OjXl/ykfMMInBK+uVdfIVakVe7W7Lg3wfXUNyS3Q1HWLFRwZIjhqiCGbslummPDnmb7vIekS0C1vw==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.7.4.tgz",
+					"integrity": "sha512-VB7gWZ2fDkSuqW6b1AKXkJWO5NyNI3bFL/kK79/30moK57blr6NbH8xcl2XcKCwOmJosftWunZqfO84IGq3ZZg==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.7.4.tgz",
+					"integrity": "sha512-pP0tfgg9hsZWo5ZboYGuBn/bbYT/hdLPVSS4NMmiRJdwWhP0IznPwN9AE1JwyGsjSPLC364I0Qh5p+EPkGPNpg==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.7.4",
+						"@babel/helper-optimise-call-expression": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+					"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+					"integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw=="
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+					"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+					"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
 			}
 		},
 		"@babel/plugin-transform-parameters": {
@@ -764,9 +1098,9 @@
 			}
 		},
 		"@babel/plugin-transform-property-literals": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.2.0.tgz",
-			"integrity": "sha512-9q7Dbk4RhgcLp8ebduOpCbtjh7C0itoLYHXd9ueASKAG/is5PQtMR5VJGka9NKqGhYEGn5ITahd4h9QeBMylWQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.7.4.tgz",
+			"integrity": "sha512-MatJhlC4iHsIskWYyawl53KuHrt+kALSADLQQ/HkhTjX954fkxIEh4q5slL4oRAnsm/eDoZ4q0CIZpcqBuxhJQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -887,15 +1221,31 @@
 			}
 		},
 		"@babel/register": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.6.0.tgz",
-			"integrity": "sha512-78BomdN8el+x/nkup9KwtjJXuptW5oXMFmP11WoM2VJBjxrKv4grC3qjpLL8RGGUYUGsm57xnjYFM2uom+jWUQ==",
+			"version": "7.7.7",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.7.7.tgz",
+			"integrity": "sha512-S2mv9a5dc2pcpg/ConlKZx/6wXaEwHeqfo7x/QbXsdCAZm+WJC1ekVvL1TVxNsedTs5y/gG63MhJTEsmwmjtiA==",
 			"requires": {
 				"find-cache-dir": "^2.0.0",
 				"lodash": "^4.17.13",
-				"mkdirp": "^0.5.1",
+				"make-dir": "^2.1.0",
 				"pirates": "^4.0.0",
-				"source-map-support": "^0.5.9"
+				"source-map-support": "^0.5.16"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"source-map-support": {
+					"version": "0.5.16",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+					"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					}
+				}
 			}
 		},
 		"@babel/runtime": {
@@ -979,9 +1329,9 @@
 			}
 		},
 		"@hapi/address": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.1.tgz",
-			"integrity": "sha512-DYuHzu978pP1XW1GD3HGvLnAFjbQTIgc2+V153FGkbS2pgo9haigCdwBnUDrbhaOkgiJlbZvoEqDrcxSLHpiWA=="
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-2.1.4.tgz",
+			"integrity": "sha512-QD1PhQk+s31P1ixsX0H0Suoupp3VMXzIVMSwobR3F3MSUO2YCV0B7xqLcUw/Bh8yuvd3LhpyqLQWTNcRmp6IdQ=="
 		},
 		"@hapi/bourne": {
 			"version": "1.3.2",
@@ -989,9 +1339,9 @@
 			"integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA=="
 		},
 		"@hapi/hoek": {
-			"version": "8.2.2",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.2.2.tgz",
-			"integrity": "sha512-18P3VwngjNEcmvPj1mmiHLPyUPjhPAxIyJKDj4PRIY0F5ac3P0Vd0hkASPyWXHK0rfY3P9N2FoxV8ZuYaRBZ1g=="
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.0.tgz",
+			"integrity": "sha512-7XYT10CZfPsH7j9F1Jmg1+d0ezOux2oM2GfArAzLwWe4mE2Dr3hVjsAL6+TFY49RRJlCdJDMw3nJsLFroTc8Kw=="
 		},
 		"@hapi/joi": {
 			"version": "15.1.1",
@@ -1005,11 +1355,11 @@
 			}
 		},
 		"@hapi/topo": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.3.tgz",
-			"integrity": "sha512-JmS9/vQK6dcUYn7wc2YZTqzIKubAQcJKu2KCKAru6es482U5RT5fP1EXCPtlXpiK7PR0On/kpQKI4fRKkzpZBQ==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-3.1.6.tgz",
+			"integrity": "sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==",
 			"requires": {
-				"@hapi/hoek": "8.x.x"
+				"@hapi/hoek": "^8.3.0"
 			}
 		},
 		"@jest/console": {
@@ -1291,9 +1641,9 @@
 			}
 		},
 		"@react-native-community/cli-platform-ios": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-2.9.0.tgz",
-			"integrity": "sha512-vg6EOamtFaaQ02FiWu+jzJTfeTJ0OVjJSAoR2rhJKNye6RgJLoQlfp0Hg3waF6XrO72a7afYZsPdKSlN3ewlHg==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/@react-native-community/cli-platform-ios/-/cli-platform-ios-2.10.0.tgz",
+			"integrity": "sha512-z5BQKyT/bgTSdHhvsFNf++6VP50vtOOaITnNKvw4954wURjv5JOQh1De3BngyaDOoGfV1mXkCxutqAXqSeuIjw==",
 			"requires": {
 				"@react-native-community/cli-tools": "^2.8.3",
 				"chalk": "^2.4.2",
@@ -1846,9 +2196,9 @@
 			"integrity": "sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ=="
 		},
 		"babel-preset-fbjs": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.2.0.tgz",
-			"integrity": "sha512-5Jo+JeWiVz2wHUUyAlvb/sSYnXNig9r+HqGAOSfh5Fzxp7SnAaR/tEGRJ1ZX7C77kfk82658w6R5Z+uPATTD9g==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-3.3.0.tgz",
+			"integrity": "sha512-7QTLTCd2gwB2qGoi5epSULMHugSVgpcVt5YAeiFO9ABLrutDQzKfGwzxgZHLpugq8qMdg/DhRZDZ5CLKxBkEbw==",
 			"requires": {
 				"@babel/plugin-proposal-class-properties": "^7.0.0",
 				"@babel/plugin-proposal-object-rest-spread": "^7.0.0",
@@ -1967,24 +2317,24 @@
 			}
 		},
 		"big-integer": {
-			"version": "1.6.44",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.44.tgz",
-			"integrity": "sha512-7MzElZPTyJ2fNvBkPxtFQ2fWIkVmuzw41+BZHSzpEq3ymB2MfeKp1+yXl/tS75xCx+WnyV+yb0kp+K1C3UNwmQ=="
+			"version": "1.6.48",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+			"integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
 		},
 		"bplist-creator": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
-			"integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
+			"integrity": "sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==",
 			"requires": {
 				"stream-buffers": "~2.2.0"
 			}
 		},
 		"bplist-parser": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
-			"integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+			"integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
 			"requires": {
-				"big-integer": "^1.6.7"
+				"big-integer": "^1.6.44"
 			}
 		},
 		"brace-expansion": {
@@ -2109,8 +2459,7 @@
 		"camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-			"dev": true
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -2144,8 +2493,7 @@
 		"ci-info": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-			"dev": true
+			"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
 		},
 		"class-utils": {
 			"version": "0.3.6",
@@ -2279,9 +2627,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.20.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -2357,9 +2705,9 @@
 			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
 		},
 		"core-js": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+			"version": "2.6.11",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -2375,17 +2723,6 @@
 				"is-directory": "^0.3.1",
 				"js-yaml": "^3.13.1",
 				"parse-json": "^4.0.0"
-			},
-			"dependencies": {
-				"js-yaml": {
-					"version": "3.13.1",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				}
 			}
 		},
 		"create-react-class": {
@@ -2480,9 +2817,9 @@
 			}
 		},
 		"dayjs": {
-			"version": "1.8.16",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.16.tgz",
-			"integrity": "sha512-XPmqzWz/EJiaRHjBqSJ2s6hE/BUoCIHKgdS2QPtTQtKcS9E4/Qn0WomoH1lXanWCzri+g7zPcuNV4aTZ8PMORQ=="
+			"version": "1.8.18",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.18.tgz",
+			"integrity": "sha512-JBMJZghNK8TtuoPnKNIzW9xavVVigld/zmZNpZSyQbkb2Opp55YIfZUpE4OEqPF/iyUVQTKcn1bC2HtC8B7s3g=="
 		},
 		"debug": {
 			"version": "2.6.9",
@@ -2665,9 +3002,9 @@
 			}
 		},
 		"envinfo": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.3.1.tgz",
-			"integrity": "sha512-GvXiDTqLYrORVSCuJCsWHPXF5BFvoWMQA9xX4YVjPT1jyS3aZEHUBwjzxU/6LTPF9ReHgVEbX7IEN5UvSXHw/A=="
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.0.tgz",
+			"integrity": "sha512-jDgnJaF/Btomk+m3PZDTTCb5XIIIX3zYItnCRfF73zVgvinLoRomuhi75Y4su0PtQxWz4v66XnLLckyvyJTOIQ=="
 		},
 		"error-ex": {
 			"version": "1.3.2",
@@ -3541,7 +3878,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
 			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-			"dev": true,
 			"requires": {
 				"locate-path": "^3.0.0"
 			}
@@ -4459,7 +4795,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
 			"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-			"dev": true,
 			"requires": {
 				"ci-info": "^2.0.0"
 			}
@@ -4935,7 +5270,6 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
 			"integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
-			"dev": true,
 			"requires": {
 				"@jest/types": "^24.9.0",
 				"anymatch": "^2.0.0",
@@ -4955,7 +5289,6 @@
 					"version": "2.2.4",
 					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 					"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-					"dev": true,
 					"requires": {
 						"loose-envify": "^1.0.0"
 					}
@@ -5243,7 +5576,6 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
 			"integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
-			"dev": true,
 			"requires": {
 				"@jest/console": "^24.9.0",
 				"@jest/fake-timers": "^24.9.0",
@@ -5262,20 +5594,17 @@
 				"callsites": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-					"dev": true
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
 				},
 				"slash": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-					"dev": true
+					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -5283,7 +5612,6 @@
 			"version": "24.9.0",
 			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
 			"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
-			"dev": true,
 			"requires": {
 				"@jest/types": "^24.9.0",
 				"camelcase": "^5.3.1",
@@ -5333,9 +5661,9 @@
 			}
 		},
 		"jetifier": {
-			"version": "1.6.4",
-			"resolved": "https://registry.npmjs.org/jetifier/-/jetifier-1.6.4.tgz",
-			"integrity": "sha512-+f/4OLeqY8RAmXnonI1ffeY1DR8kMNJPhv5WMFehchf7U71cjMQVKkOz1n6asz6kfVoAqKNWJz1A/18i18AcXA=="
+			"version": "1.6.5",
+			"resolved": "https://registry.npmjs.org/jetifier/-/jetifier-1.6.5.tgz",
+			"integrity": "sha512-T7yzBSu9PR+DqjYt+I0KVO1XTb1QhAfHnXV5Nd3xpbXM6Xg4e3vP60Q4qkNU8Fh6PHC2PivPUNN3rY7G2MxcDQ=="
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -5346,7 +5674,6 @@
 			"version": "3.13.1",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
 			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"
@@ -5535,8 +5862,7 @@
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-			"dev": true
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
 		},
 		"levn": {
 			"version": "0.3.0",
@@ -5615,9 +5941,9 @@
 			}
 		},
 		"logkitty": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/logkitty/-/logkitty-0.6.0.tgz",
-			"integrity": "sha512-+F1ROENmfG3b4N9WGlRz5QGTBw/xgjZe2JzZLADYeCmzdId5c+QI7WTGRofs/10hwP84aAmjK2WStx+/oQVnwA==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/logkitty/-/logkitty-0.6.1.tgz",
+			"integrity": "sha512-cHuXN8qUZuzX/7kB6VyS7kB4xyD24e8gyHXIFNhIv+fjW3P+jEXNUhj0o/7qWJtv7UZpbnPgUqzu/AZQ8RAqxQ==",
 			"requires": {
 				"ansi-fragments": "^0.2.1",
 				"dayjs": "^1.8.15",
@@ -5762,20 +6088,10 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 				},
-				"callsites": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
-				},
 				"camelcase": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-				},
-				"ci-info": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
 				},
 				"cliui": {
 					"version": "3.2.0",
@@ -5846,26 +6162,10 @@
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
 					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
 				},
-				"invariant": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-					"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-					"requires": {
-						"loose-envify": "^1.0.0"
-					}
-				},
 				"invert-kv": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-				},
-				"is-ci": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-					"requires": {
-						"ci-info": "^2.0.0"
-					}
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
@@ -5873,51 +6173,6 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
 						"number-is-nan": "^1.0.0"
-					}
-				},
-				"jest-haste-map": {
-					"version": "24.9.0",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
-					"integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
-					"requires": {
-						"@jest/types": "^24.9.0",
-						"anymatch": "^2.0.0",
-						"fb-watchman": "^2.0.0",
-						"fsevents": "^1.2.7",
-						"graceful-fs": "^4.1.15",
-						"invariant": "^2.2.4",
-						"jest-serializer": "^24.9.0",
-						"jest-util": "^24.9.0",
-						"jest-worker": "^24.9.0",
-						"micromatch": "^3.1.10",
-						"sane": "^4.0.3",
-						"walker": "^1.0.7"
-					}
-				},
-				"jest-util": {
-					"version": "24.9.0",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
-					"integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
-					"requires": {
-						"@jest/console": "^24.9.0",
-						"@jest/fake-timers": "^24.9.0",
-						"@jest/source-map": "^24.9.0",
-						"@jest/test-result": "^24.9.0",
-						"@jest/types": "^24.9.0",
-						"callsites": "^3.0.0",
-						"chalk": "^2.0.1",
-						"graceful-fs": "^4.1.15",
-						"is-ci": "^2.0.0",
-						"mkdirp": "^0.5.1",
-						"slash": "^2.0.0",
-						"source-map": "^0.6.0"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.6.1",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-						}
 					}
 				},
 				"jsonfile": {
@@ -6074,16 +6329,6 @@
 						"error-ex": "^1.2.0"
 					}
 				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-				},
-				"path-parse": {
-					"version": "1.0.6",
-					"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-					"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-				},
 				"path-type": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -6116,19 +6361,6 @@
 						"read-pkg": "^2.0.0"
 					}
 				},
-				"resolve": {
-					"version": "1.12.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-					"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
-					"requires": {
-						"path-parse": "^1.0.6"
-					}
-				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
-				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -6136,21 +6368,6 @@
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-				},
-				"throat": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-					"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				},
 				"y18n": {
 					"version": "3.2.1",
@@ -6244,31 +6461,6 @@
 				"metro-cache": "0.54.1",
 				"metro-core": "0.54.1",
 				"pretty-format": "^24.7.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-				},
-				"jest-validate": {
-					"version": "24.9.0",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.9.0.tgz",
-					"integrity": "sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==",
-					"requires": {
-						"@jest/types": "^24.9.0",
-						"camelcase": "^5.3.1",
-						"chalk": "^2.0.1",
-						"jest-get-type": "^24.9.0",
-						"leven": "^3.1.0",
-						"pretty-format": "^24.9.0"
-					}
-				},
-				"leven": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-					"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
-				}
 			}
 		},
 		"metro-core": {
@@ -6280,82 +6472,6 @@
 				"lodash.throttle": "^4.1.1",
 				"metro-resolver": "0.54.1",
 				"wordwrap": "^1.0.0"
-			},
-			"dependencies": {
-				"callsites": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
-				},
-				"ci-info": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
-				},
-				"invariant": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-					"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-					"requires": {
-						"loose-envify": "^1.0.0"
-					}
-				},
-				"is-ci": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-					"requires": {
-						"ci-info": "^2.0.0"
-					}
-				},
-				"jest-haste-map": {
-					"version": "24.9.0",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
-					"integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
-					"requires": {
-						"@jest/types": "^24.9.0",
-						"anymatch": "^2.0.0",
-						"fb-watchman": "^2.0.0",
-						"fsevents": "^1.2.7",
-						"graceful-fs": "^4.1.15",
-						"invariant": "^2.2.4",
-						"jest-serializer": "^24.9.0",
-						"jest-util": "^24.9.0",
-						"jest-worker": "^24.9.0",
-						"micromatch": "^3.1.10",
-						"sane": "^4.0.3",
-						"walker": "^1.0.7"
-					}
-				},
-				"jest-util": {
-					"version": "24.9.0",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
-					"integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
-					"requires": {
-						"@jest/console": "^24.9.0",
-						"@jest/fake-timers": "^24.9.0",
-						"@jest/source-map": "^24.9.0",
-						"@jest/test-result": "^24.9.0",
-						"@jest/types": "^24.9.0",
-						"callsites": "^3.0.0",
-						"chalk": "^2.0.1",
-						"graceful-fs": "^4.1.15",
-						"is-ci": "^2.0.0",
-						"mkdirp": "^0.5.1",
-						"slash": "^2.0.0",
-						"source-map": "^0.6.0"
-					}
-				},
-				"slash": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-					"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
 			}
 		},
 		"metro-inspector-proxy": {
@@ -6532,11 +6648,6 @@
 						"error-ex": "^1.2.0"
 					}
 				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-				},
 				"path-type": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -6576,16 +6687,6 @@
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
-				},
-				"strip-bom": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-					"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				},
 				"y18n": {
 					"version": "3.2.1",
@@ -6628,27 +6729,6 @@
 			"integrity": "sha512-z+pOPna/8IxD4OhjW6Xo1mV2EszgqqQHqBm1FdmtdF6IpWkQp33qpDBNEi9NGZTOr7pp2bvcxZnvNJdC2lrK9Q==",
 			"requires": {
 				"uglify-es": "^3.1.9"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.13.0",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"uglify-es": {
-					"version": "3.3.9",
-					"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
-					"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
-					"requires": {
-						"commander": "~2.13.0",
-						"source-map": "~0.6.1"
-					}
-				}
 			}
 		},
 		"metro-react-native-babel-preset": {
@@ -6770,16 +6850,6 @@
 				"ob1": "0.55.0",
 				"source-map": "^0.5.6",
 				"vlq": "^1.0.0"
-			},
-			"dependencies": {
-				"invariant": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-					"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-					"requires": {
-						"loose-envify": "^1.0.0"
-					}
-				}
 			}
 		},
 		"metro-symbolicate": {
@@ -7248,6 +7318,16 @@
 				"wcwidth": "^1.0.1"
 			}
 		},
+		"os-locale": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+			"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+			"requires": {
+				"execa": "^1.0.0",
+				"lcid": "^2.0.0",
+				"mem": "^4.0.0"
+			}
+		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -7350,6 +7430,11 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
 			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+		},
+		"path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
 		},
 		"path-is-absolute": {
 			"version": "1.0.1",
@@ -7684,13 +7769,13 @@
 			},
 			"dependencies": {
 				"@react-native-community/cli": {
-					"version": "2.9.0",
-					"resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-2.9.0.tgz",
-					"integrity": "sha512-6TYkrR1pwIEPpiPZnOYscCGr5Xh8RijqBPVAOGTaEdpQQpc/J7GDPrePwbyTzwmCPtiK6XT+T5+1AiAK5bz/sw==",
+					"version": "2.10.0",
+					"resolved": "https://registry.npmjs.org/@react-native-community/cli/-/cli-2.10.0.tgz",
+					"integrity": "sha512-KldnMwYzNJlbbJpJQ4AxwTMp89qqwilI1lEvCAwKmiviWuyYGACCQsXI7ikShRaQeakc28zyN2ldbkbrHeOoJA==",
 					"requires": {
 						"@hapi/joi": "^15.0.3",
 						"@react-native-community/cli-platform-android": "^2.9.0",
-						"@react-native-community/cli-platform-ios": "^2.9.0",
+						"@react-native-community/cli-platform-ios": "^2.10.0",
 						"@react-native-community/cli-tools": "^2.8.3",
 						"chalk": "^2.4.2",
 						"commander": "^2.19.0",
@@ -7721,14 +7806,6 @@
 						"serve-static": "^1.13.1",
 						"shell-quote": "1.6.1",
 						"ws": "^1.1.0"
-					}
-				},
-				"invariant": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-					"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-					"requires": {
-						"loose-envify": "^1.0.0"
 					}
 				},
 				"scheduler": {
@@ -8275,12 +8352,12 @@
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
 		},
 		"simple-plist": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.0.0.tgz",
-			"integrity": "sha512-043L2rO80LVF7zfZ+fqhsEkoJFvW8o59rt/l4ctx1TJWoTx7/jkiS1R5TatD15Z1oYnuLJytzE7gcnnBuIPL2g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.1.0.tgz",
+			"integrity": "sha512-2i5Tc0BYAqppM7jVzmNrI+aEUntPolIq4fDgji6WuNNn1D/qYdn2KwoLhZdzQkE04lu9L5tUoeJsjuJAvd+lFg==",
 			"requires": {
-				"bplist-creator": "0.0.7",
-				"bplist-parser": "0.1.1",
+				"bplist-creator": "0.0.8",
+				"bplist-parser": "0.2.0",
 				"plist": "^3.0.1"
 			}
 		},
@@ -8428,6 +8505,7 @@
 			"version": "0.5.13",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
 			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -8436,7 +8514,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -8509,11 +8588,11 @@
 			"integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
 		},
 		"stacktrace-parser": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.6.tgz",
-			"integrity": "sha512-wXhu0Z8YgCGigUtHQq+J7pjXCppk3Um5DwH4qskOKHMlJmKwuuUSm+wDAgU7t4sbVjvuDTNGwOfFKgjMEqSflA==",
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.8.tgz",
+			"integrity": "sha512-ig5rHJSdJrAsVqdb3oAI/8C6aQ7dEwJXoy/TIEIOTzdJHssmn12o6RsFoeQSLHoKjq0lX+kqhmnLDpyQTuWiJA==",
 			"requires": {
-				"type-fest": "^0.3.0"
+				"type-fest": "^0.7.1"
 			}
 		},
 		"static-extend": {
@@ -8641,8 +8720,7 @@
 		"strip-bom": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-			"dev": true
+			"integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
 		},
 		"strip-eof": {
 			"version": "1.0.0",
@@ -8744,8 +8822,7 @@
 		"throat": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
-			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
-			"dev": true
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
 		},
 		"through": {
 			"version": "2.3.8",
@@ -8891,9 +8968,9 @@
 			}
 		},
 		"type-fest": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-			"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+			"integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
 		},
 		"typedarray": {
 			"version": "0.0.6",
@@ -8901,9 +8978,30 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"ua-parser-js": {
-			"version": "0.7.20",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-			"integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
+			"version": "0.7.21",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
+			"integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
+		},
+		"uglify-es": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.9.tgz",
+			"integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
+			"requires": {
+				"commander": "~2.13.0",
+				"source-map": "~0.6.1"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.13.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA=="
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
+			}
 		},
 		"uglify-js": {
 			"version": "3.7.3",
@@ -9171,8 +9269,7 @@
 		"which-module": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-			"dev": true
+			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 		},
 		"word-wrap": {
 			"version": "1.2.3",
@@ -9261,9 +9358,9 @@
 			}
 		},
 		"xcode": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/xcode/-/xcode-2.0.0.tgz",
-			"integrity": "sha512-5xF6RCjAdDEiEsbbZaS/gBRt3jZ/177otZcpoLCjGN/u1LrfgH7/Sgeeavpr/jELpyDqN2im3AKosl2G2W8hfw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/xcode/-/xcode-2.1.0.tgz",
+			"integrity": "sha512-uCrmPITrqTEzhn0TtT57fJaNaw8YJs1aCzs+P/QqxsDbvPZSv7XMPPwXrKvHtD6pLjBM/NaVwraWJm8q83Y4iQ==",
 			"requires": {
 				"simple-plist": "^1.0.0",
 				"uuid": "^3.3.2"
@@ -9289,9 +9386,9 @@
 			}
 		},
 		"xmldom": {
-			"version": "0.1.27",
-			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-			"integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+			"version": "0.1.31",
+			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+			"integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
 		},
 		"xpipe": {
 			"version": "1.0.5",
@@ -9347,24 +9444,6 @@
 						"wrap-ansi": "^2.0.0"
 					}
 				},
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"os-locale": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
-					"requires": {
-						"execa": "^1.0.0",
-						"lcid": "^2.0.0",
-						"mem": "^4.0.0"
-					}
-				},
 				"strip-ansi": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -9372,11 +9451,6 @@
 					"requires": {
 						"ansi-regex": "^3.0.0"
 					}
-				},
-				"which-module": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
 				}
 			}
 		},
@@ -9387,13 +9461,6 @@
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-				}
 			}
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,18 +13,18 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
-			"integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
+			"version": "7.7.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.7.tgz",
+			"integrity": "sha512-jlSjuj/7z138NLZALxVgrx13AOtqip42ATZP7+kYl53GvDV6+4dCek1mVUo8z8c8Xnw/mx2q3d9HWh3griuesQ==",
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.6.0",
-				"@babel/helpers": "^7.6.0",
-				"@babel/parser": "^7.6.0",
-				"@babel/template": "^7.6.0",
-				"@babel/traverse": "^7.6.0",
-				"@babel/types": "^7.6.0",
-				"convert-source-map": "^1.1.0",
+				"@babel/generator": "^7.7.7",
+				"@babel/helpers": "^7.7.4",
+				"@babel/parser": "^7.7.7",
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4",
+				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"json5": "^2.1.0",
 				"lodash": "^4.17.13",
@@ -33,10 +33,91 @@
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
+				"@babel/generator": {
+					"version": "7.7.7",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+					"integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+					"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
 				"@babel/parser": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-					"integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ=="
+					"version": "7.7.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+					"integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw=="
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+					"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+					"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"convert-source-map": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+					"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+					"requires": {
+						"safe-buffer": "~5.1.1"
+					}
 				},
 				"debug": {
 					"version": "4.1.1",
@@ -261,13 +342,106 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz",
-			"integrity": "sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.7.4.tgz",
+			"integrity": "sha512-ak5NGZGJ6LV85Q1Zc9gn2n+ayXOizryhjSUBTdu5ih1tlVCJeuQENzc4ItyCVhINVXvIT/ZQ4mheGIsfBkpskg==",
 			"requires": {
-				"@babel/template": "^7.6.0",
-				"@babel/traverse": "^7.6.0",
-				"@babel/types": "^7.6.0"
+				"@babel/template": "^7.7.4",
+				"@babel/traverse": "^7.7.4",
+				"@babel/types": "^7.7.4"
+			},
+			"dependencies": {
+				"@babel/generator": {
+					"version": "7.7.7",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+					"integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+					"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+					"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+					"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.7",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+					"integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw=="
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+					"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+					"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+					"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
 			}
 		},
 		"@babel/highlight": {
@@ -725,9 +899,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
-			"integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
+			"version": "7.7.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+			"integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
@@ -1332,9 +1506,9 @@
 			}
 		},
 		"acorn": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-			"integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+			"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
 			"dev": true
 		},
 		"acorn-globals": {
@@ -1356,9 +1530,9 @@
 			}
 		},
 		"acorn-jsx": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.2.tgz",
-			"integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+			"integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw==",
 			"dev": true
 		},
 		"acorn-walk": {
@@ -2172,6 +2346,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
 			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -2579,9 +2754,9 @@
 			}
 		},
 		"eslint": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.3.0.tgz",
-			"integrity": "sha512-ZvZTKaqDue+N8Y9g0kp6UPZtS4FSY3qARxBs7p4f0H0iof381XHduqVerFWtK8DPtKmemqbqCFENWSQgPR/Gow==",
+			"version": "6.8.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
+			"integrity": "sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -2591,19 +2766,19 @@
 				"debug": "^4.0.1",
 				"doctrine": "^3.0.0",
 				"eslint-scope": "^5.0.0",
-				"eslint-utils": "^1.4.2",
+				"eslint-utils": "^1.4.3",
 				"eslint-visitor-keys": "^1.1.0",
-				"espree": "^6.1.1",
+				"espree": "^6.1.2",
 				"esquery": "^1.0.1",
 				"esutils": "^2.0.2",
 				"file-entry-cache": "^5.0.1",
 				"functional-red-black-tree": "^1.0.1",
 				"glob-parent": "^5.0.0",
-				"globals": "^11.7.0",
+				"globals": "^12.1.0",
 				"ignore": "^4.0.6",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
-				"inquirer": "^6.4.1",
+				"inquirer": "^7.0.0",
 				"is-glob": "^4.0.0",
 				"js-yaml": "^3.13.1",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
@@ -2612,7 +2787,7 @@
 				"minimatch": "^3.0.4",
 				"mkdirp": "^0.5.1",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.8.2",
+				"optionator": "^0.8.3",
 				"progress": "^2.0.0",
 				"regexpp": "^2.0.1",
 				"semver": "^6.1.2",
@@ -2623,11 +2798,35 @@
 				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
+				"ansi-escapes": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+					"integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.8.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
 				"chardet": {
 					"version": "0.7.0",
 					"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 					"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 					"dev": true
+				},
+				"cli-cursor": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+					"integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+					"dev": true,
+					"requires": {
+						"restore-cursor": "^3.1.0"
+					}
 				},
 				"debug": {
 					"version": "4.1.1",
@@ -2647,6 +2846,12 @@
 						"esutils": "^2.0.2"
 					}
 				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
 				"eslint-scope": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
@@ -2655,6 +2860,15 @@
 					"requires": {
 						"esrecurse": "^4.1.0",
 						"estraverse": "^4.1.1"
+					}
+				},
+				"eslint-utils": {
+					"version": "1.4.3",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+					"integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+					"dev": true,
+					"requires": {
+						"eslint-visitor-keys": "^1.1.0"
 					}
 				},
 				"external-editor": {
@@ -2668,6 +2882,24 @@
 						"tmp": "^0.0.33"
 					}
 				},
+				"figures": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+					"integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+					"dev": true,
+					"requires": {
+						"escape-string-regexp": "^1.0.5"
+					}
+				},
+				"globals": {
+					"version": "12.3.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
+					"integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.8.1"
+					}
+				},
 				"ignore": {
 					"version": "4.0.6",
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -2675,9 +2907,9 @@
 					"dev": true
 				},
 				"import-fresh": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
-					"integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
 					"dev": true,
 					"requires": {
 						"parent-module": "^1.0.0",
@@ -2685,25 +2917,31 @@
 					}
 				},
 				"inquirer": {
-					"version": "6.5.2",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
-					"integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
+					"integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.2.0",
+						"ansi-escapes": "^4.2.1",
 						"chalk": "^2.4.2",
-						"cli-cursor": "^2.1.0",
+						"cli-cursor": "^3.1.0",
 						"cli-width": "^2.0.0",
 						"external-editor": "^3.0.3",
-						"figures": "^2.0.0",
-						"lodash": "^4.17.12",
-						"mute-stream": "0.0.7",
+						"figures": "^3.0.0",
+						"lodash": "^4.17.15",
+						"mute-stream": "0.0.8",
 						"run-async": "^2.2.0",
-						"rxjs": "^6.4.0",
-						"string-width": "^2.1.0",
+						"rxjs": "^6.5.3",
+						"string-width": "^4.1.0",
 						"strip-ansi": "^5.1.0",
 						"through": "^2.3.6"
 					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
 				},
 				"ms": {
 					"version": "2.1.2",
@@ -2711,16 +2949,55 @@
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
 				},
+				"mute-stream": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+					"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+					"dev": true
+				},
+				"onetime": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+					"integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+					"dev": true,
+					"requires": {
+						"mimic-fn": "^2.1.0"
+					}
+				},
+				"optionator": {
+					"version": "0.8.3",
+					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+					"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+					"dev": true,
+					"requires": {
+						"deep-is": "~0.1.3",
+						"fast-levenshtein": "~2.0.6",
+						"levn": "~0.3.0",
+						"prelude-ls": "~1.1.2",
+						"type-check": "~0.3.2",
+						"word-wrap": "~1.2.3"
+					}
+				},
 				"resolve-from": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 					"dev": true
 				},
+				"restore-cursor": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+					"integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+					"dev": true,
+					"requires": {
+						"onetime": "^5.1.0",
+						"signal-exit": "^3.0.2"
+					}
+				},
 				"rxjs": {
-					"version": "6.5.3",
-					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
-					"integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+					"version": "6.5.4",
+					"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
+					"integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
 					"dev": true,
 					"requires": {
 						"tslib": "^1.9.0"
@@ -2730,6 +3007,34 @@
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+					"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					},
+					"dependencies": {
+						"strip-ansi": {
+							"version": "6.0.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+							"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^5.0.0"
+							}
+						}
+					}
+				},
+				"type-fest": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 					"dev": true
 				}
 			}
@@ -2848,13 +3153,13 @@
 			"dev": true
 		},
 		"espree": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.1.tgz",
-			"integrity": "sha512-EYbr8XZUhWbYCqQRW0duU5LxzL5bETN6AjKBGy1302qqzPaCH10QbRg3Wvco79Z8x9WbiE8HYB4e75xl6qUYvQ==",
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
+			"integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
 			"dev": true,
 			"requires": {
-				"acorn": "^7.0.0",
-				"acorn-jsx": "^5.0.2",
+				"acorn": "^7.1.0",
+				"acorn-jsx": "^5.1.0",
 				"eslint-visitor-keys": "^1.1.0"
 			}
 		},
@@ -3852,9 +4157,9 @@
 			}
 		},
 		"glob-parent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-			"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+			"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"
@@ -3885,9 +4190,9 @@
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
 		},
 		"handlebars": {
-			"version": "4.4.5",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.5.tgz",
-			"integrity": "sha512-0Ce31oWVB7YidkaTq33ZxEbN+UDxMMgThvCe8ptgQViymL5DPis9uLdTA13MiRPhgvqyxIegugrP97iK3JeBHg==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+			"integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
@@ -4104,9 +4409,9 @@
 			}
 		},
 		"invariant": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -5152,9 +5457,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
+			"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
 			"requires": {
 				"minimist": "^1.2.0"
 			}
@@ -6347,9 +6652,9 @@
 			}
 		},
 		"metro-react-native-babel-preset": {
-			"version": "0.56.0",
-			"resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.56.0.tgz",
-			"integrity": "sha512-MAo1fm0dNn6MVZmylaz6k2HC1MINHLTLfE7O3a9Xz3fAtbGbApisp06rBUfK5uUqIJDmAaKgbiT34lHJSIiE6Q==",
+			"version": "0.56.3",
+			"resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.56.3.tgz",
+			"integrity": "sha512-tGPzX2ZwI8vQ8SiNVBPUIgKqmaRNVB6rtJtHCBQZAYRiMbxh0NHCUoFfKBej6U5qVgxiYYHyN8oB23evG4/Oow==",
 			"dev": true,
 			"requires": {
 				"@babel/plugin-proposal-class-properties": "^7.0.0",
@@ -7057,9 +7362,9 @@
 			"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
 		},
 		"path-parse": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"path-type": {
 			"version": "3.0.0",
@@ -7438,38 +7743,35 @@
 			}
 		},
 		"react-native-device-info": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-2.3.2.tgz",
-			"integrity": "sha512-ccpPuUbwhw5uYdVwN1UJp6ykMZz6U/u82HNM3oJ7O6MP8RIMlMDkHbqR4O0sDtUSuRMGiqqRzFtmOLFYeQ0ODw=="
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-3.1.4.tgz",
+			"integrity": "sha512-r+7APHkPO9EA/9w3e9K7yrFigaU+0/g8i3psrNUwCGFxoDewkCHOPj/1YZnAPUwPxgyG3svjZXeCtymI3xcSlA=="
 		},
 		"react-native-key-pair": {
-			"version": "git+https://github.com/pmusaraj/react-native-key-pair.git#606700d9a16f6c0ec768f3a553c489344ec13cae",
+			"version": "git+https://github.com/pmusaraj/react-native-key-pair.git#5651ef10987574bae58f794030133e4b5da23779",
 			"from": "git+https://github.com/pmusaraj/react-native-key-pair.git"
 		},
 		"react-native-onesignal": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/react-native-onesignal/-/react-native-onesignal-3.3.2.tgz",
-			"integrity": "sha512-SZBGVVWZ5xAe2ALeE2L5HBIh6hfFKjFqARrV8U80zyLFUN8QatRy1eaXKAHgb7wvnCGR8FoNKI8qF+Z4kIKgjg==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/react-native-onesignal/-/react-native-onesignal-3.6.1.tgz",
+			"integrity": "sha512-2Ci0xZhk4mpt+UpeCyz++VV31DisBMR0GpOzfBGk67AZyN+BNOY50Nhr11f4mQFO+un7i/18I2hpjAF//gYdvg==",
 			"requires": {
 				"invariant": "^2.2.2"
 			}
 		},
 		"react-native-webview": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-7.0.4.tgz",
-			"integrity": "sha512-Rs2RpbRPTdn7Hr4Sk77iQlbCnX7cGu0LN/AlhU9yyxh5yBqdCNfE7nYxnXZNJqHRQNLZgcp+Fj6NKOpcEq/tuw==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-7.6.0.tgz",
+			"integrity": "sha512-IQWtIpCTYb4dTshAJO3hMM9Ms5T6KRpk6qWqgBTGMdmgeEvSxWz9l7Og1ALhb7T7NoAnPy8w/dQmD9LlbGGs5g==",
 			"requires": {
-				"escape-string-regexp": "1.0.5",
+				"escape-string-regexp": "2.0.0",
 				"invariant": "2.2.4"
 			},
 			"dependencies": {
-				"invariant": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-					"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-					"requires": {
-						"loose-envify": "^1.0.0"
-					}
+				"escape-string-regexp": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
 				}
 			}
 		},
@@ -7483,9 +7785,9 @@
 			}
 		},
 		"react-refresh": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.1.tgz",
-			"integrity": "sha512-My+vtJ3hCT2sOog3g0h9a9J96IaHkIAcencxhe7HtMVQYpNNyJnr+bE9bjcwfwTBi13tkb7oDDCbRtfvK7iiKQ==",
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.2.tgz",
+			"integrity": "sha512-kv5QlFFSZWo7OlJFNYbxRtY66JImuP2LcrFgyJfQaf85gSP+byzG21UbDQEYjU7f//ny8rwiEkO6py2Y+fEgAQ==",
 			"dev": true
 		},
 		"react-test-renderer": {
@@ -7719,11 +8021,11 @@
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
 		},
 		"resolve": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-			"integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
+			"integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "^1.0.6"
 			}
 		},
 		"resolve-cwd": {
@@ -8604,9 +8906,9 @@
 			"integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
 		},
 		"uglify-js": {
-			"version": "3.6.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz",
-			"integrity": "sha512-9Yc2i881pF4BPGhjteCXQNaXx1DCwm3dtOyBaG2hitHjLWOczw/ki8vD1bqyT3u6K0Ms/FpCShkmfg+FtlOfYA==",
+			"version": "3.7.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.3.tgz",
+			"integrity": "sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -8870,6 +9172,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
 			"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+			"dev": true
+		},
+		"word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
 		},
 		"wordwrap": {

--- a/package.json
+++ b/package.json
@@ -8,22 +8,22 @@
 		"lint": "eslint ."
 	},
 	"dependencies": {
+		"@react-native-community/async-storage": "1.6.1",
 		"react": "16.8.6",
 		"react-native": "0.60.5",
-		"react-native-webview": "^7.0.4",
-		"react-native-device-info": "2.3.2",
+		"react-native-device-info": "3.1.4",
 		"react-native-key-pair": "git+https://github.com/pmusaraj/react-native-key-pair.git",
-		"react-native-onesignal": "3.3.2",
-		"@react-native-community/async-storage": "1.6.1"
+		"react-native-onesignal": "3.6.1",
+		"react-native-webview": "^7.6.0"
 	},
 	"devDependencies": {
-		"@babel/core": "^7.5.5",
-		"@babel/runtime": "^7.5.5",
+		"@babel/core": "^7.7.7",
+		"@babel/runtime": "^7.7.7",
 		"@react-native-community/eslint-config": "^0.0.5",
 		"babel-jest": "^24.8.0",
-		"eslint": "^6.1.0",
+		"eslint": "^6.8.0",
 		"jest": "^24.8.0",
-		"metro-react-native-babel-preset": "^0.56.0",
+		"metro-react-native-babel-preset": "^0.56.3",
 		"react-test-renderer": "16.8.6"
 	},
 	"jest": {


### PR DESCRIPTION
Changes were contributed via the web interface and were copied from a local, private working copy.

App verified to successfully build and run in iOS simulator (XCode 11.3) if everything is set up properly.

Push notifications required a push key rotation (for the implementation I worked on) otherwise the upgrade appears to be seamless.

This update bumps dependencies to remove the deprecated UIWebView. UIWebView is not used in the app directly but is used to fetch device data.

See this [meta post](https://meta.discourse.org/t/whitelisted-discourse-app-with-push-notifications-via-onesignal/58247/65?u=sau226) for more details.

//cc @pmusaraj 